### PR TITLE
Add initial Python bindings and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,20 @@ ctest .
 
 # Using SealPIR
 
-Take a look at the example in `src/main.cpp` for how to use SealPIR. 
+Take a look at the example in `src/main.cpp` for how to use SealPIR.
 You can also look at the tests in the `test` folder.
+
+## Python bindings
+
+Experimental Python bindings are provided via [pybind11](https://pybind11.readthedocs.io/).
+Build and install the module locally with:
+
+```
+pip install -e python
+```
+
+An example script is available at `examples/basic_pir.py` and a pytest-based
+smoke test lives in `tests/test_pir.py`.
 
 
 ## Default parameters

--- a/examples/basic_pir.py
+++ b/examples/basic_pir.py
@@ -1,0 +1,46 @@
+"""Minimal round-trip example using SealPIR bindings."""
+
+from sealpir import (
+    PIRClient,
+    PIRServer,
+    gen_encryption_params,
+    gen_pir_params,
+)
+
+
+def main() -> None:
+    number_of_items = 16
+    size_per_item = 4
+    poly_modulus_degree = 2048
+    logt = 20
+    d = 1
+
+    enc_params = gen_encryption_params(poly_modulus_degree, logt)
+    pir_params = gen_pir_params(number_of_items, size_per_item, d, enc_params)
+
+    client = PIRClient(enc_params, pir_params)
+    server = PIRServer(enc_params, pir_params)
+
+    galois_key = client.generate_galois_keys()
+    server.set_galois_key(0, galois_key, enc_params)
+
+    # Build a tiny database of sequential bytes
+    database = bytes(range(number_of_items * size_per_item))
+    server.set_database(database, number_of_items, size_per_item)
+    server.preprocess_database()
+
+    element_index = 5
+    index = client.get_fv_index(element_index)
+    offset = client.get_fv_offset(element_index)
+
+    query = client.generate_query(index)
+    reply = server.generate_reply(query, 0)
+    result = client.decode_reply(reply, offset)
+
+    print("Retrieved:", list(result))
+    expected = database[element_index * size_per_item : (element_index + 1) * size_per_item]
+    assert result == expected
+
+
+if __name__ == "__main__":
+    main()

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,14 @@
+# SealPIR Python bindings
+
+This directory contains the packaging configuration for the `sealpir` Python
+extension. Building requires a C++17 compiler, pybind11, scikit-build-core and
+Microsoft SEAL headers.
+
+To build and install locally run:
+
+```bash
+pip install -e .
+```
+
+This will compile the extension via CMake and make the module available as
+`sealpir`.

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -1,0 +1,154 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <sstream>
+
+#include "pir.hpp"
+#include "pir_client.hpp"
+#include "pir_server.hpp"
+
+namespace py = pybind11;
+
+// Helper: create EncryptionParameters and return
+static seal::EncryptionParameters
+gen_enc_params_wrapper(std::uint32_t N, std::uint32_t logt) {
+    seal::EncryptionParameters params(seal::scheme_type::bfv);
+    gen_encryption_params(N, logt, params);
+    return params;
+}
+
+// Helper: generate PIR parameters and return
+static PirParams gen_pir_params_wrapper(std::uint64_t ele_num,
+                                       std::uint64_t ele_size,
+                                       std::uint32_t d,
+                                       const seal::EncryptionParameters &enc,
+                                       bool enable_symmetric = false,
+                                       bool enable_batching = true,
+                                       bool enable_mswitching = true) {
+    PirParams p;
+    gen_pir_params(ele_num, ele_size, d, enc, p,
+                   enable_symmetric, enable_batching, enable_mswitching);
+    return p;
+}
+
+// Wrap set_database taking Python bytes
+static void set_database_from_bytes(PIRServer &server, py::bytes db,
+                                    std::uint64_t ele_num,
+                                    std::uint64_t ele_size) {
+    std::string buffer = db;
+    auto data = std::make_unique<uint8_t[]>(buffer.size());
+    std::memcpy(data.get(), buffer.data(), buffer.size());
+    server.set_database(std::move(data), ele_num, ele_size);
+}
+
+// Wrap generate_serialized_query
+static py::bytes generate_query_serialized(PIRClient &client,
+                                           std::uint64_t index) {
+    std::stringstream stream;
+    client.generate_serialized_query(index, stream);
+    return py::bytes(stream.str());
+}
+
+// Wrap server side generation of serialized reply
+static py::bytes generate_reply_serialized(PIRServer &server,
+                                           const std::string &query,
+                                           std::uint32_t client_id) {
+    std::stringstream qs(query);
+    PirQuery q = server.deserialize_query(qs);
+    PirReply r = server.generate_reply(q, client_id);
+    std::stringstream rs;
+    server.serialize_reply(r, rs);
+    return py::bytes(rs.str());
+}
+
+// Wrap client decode from serialized reply
+static py::bytes decode_reply_serialized(PIRClient &client,
+                                         const std::string &reply,
+                                         std::uint64_t offset) {
+    std::stringstream rs(reply);
+    PirReply r;
+    while (rs.rdbuf()->in_avail() > 0) {
+        seal::Ciphertext ct;
+        ct.load(*client.context_, rs);
+        r.push_back(ct);
+    }
+    std::vector<uint8_t> result = client.decode_reply(r, offset);
+    return py::bytes(reinterpret_cast<const char *>(result.data()),
+                     result.size());
+}
+
+// Wrap generation of galois keys
+static py::bytes generate_galois_keys_serialized(PIRClient &client) {
+    auto g = client.generate_galois_keys();
+    std::string s = serialize_galoiskeys(g);
+    return py::bytes(s);
+}
+
+// Wrap server set_galois_key from serialized bytes
+static void set_galois_key_serialized(PIRServer &server, std::uint32_t client_id,
+                                      const std::string &key,
+                                      const seal::EncryptionParameters &enc) {
+    auto context = std::make_shared<seal::SEALContext>(enc, true);
+    auto g = deserialize_galoiskeys(key, context);
+    server.set_galois_key(client_id, *g);
+    delete g;
+}
+
+PYBIND11_MODULE(sealpir, m) {
+    m.doc() = "Python bindings for SealPIR";
+
+    py::class_<seal::EncryptionParameters>(m, "EncryptionParameters")
+        .def(py::init<seal::scheme_type>());
+
+    py::class_<PirParams>(m, "PirParams")
+        .def(py::init<>())
+        .def_readwrite("enable_symmetric", &PirParams::enable_symmetric)
+        .def_readwrite("enable_batching", &PirParams::enable_batching)
+        .def_readwrite("enable_mswitching", &PirParams::enable_mswitching)
+        .def_readwrite("ele_num", &PirParams::ele_num)
+        .def_readwrite("ele_size", &PirParams::ele_size)
+        .def_readwrite("elements_per_plaintext", &PirParams::elements_per_plaintext)
+        .def_readwrite("num_of_plaintexts", &PirParams::num_of_plaintexts)
+        .def_readwrite("d", &PirParams::d)
+        .def_readwrite("expansion_ratio", &PirParams::expansion_ratio)
+        .def_readwrite("nvec", &PirParams::nvec)
+        .def_readwrite("slot_count", &PirParams::slot_count);
+
+    m.def("gen_encryption_params", &gen_enc_params_wrapper,
+          py::arg("poly_modulus_degree"), py::arg("logt"),
+          "Generate SEAL encryption parameters");
+    m.def("gen_pir_params", &gen_pir_params_wrapper,
+          py::arg("ele_num"), py::arg("ele_size"), py::arg("d"),
+          py::arg("enc_params"), py::arg("enable_symmetric") = false,
+          py::arg("enable_batching") = true,
+          py::arg("enable_mswitching") = true,
+          "Generate PIR parameters");
+
+    py::class_<PIRClient>(m, "PIRClient")
+        .def(py::init<const seal::EncryptionParameters &, const PirParams &>(),
+             "Create a PIR client")
+        .def("generate_galois_keys", &generate_galois_keys_serialized,
+             "Return serialized Galois keys")
+        .def("generate_query", &generate_query_serialized,
+             py::arg("index"), "Generate serialized query")
+        .def("decode_reply", &decode_reply_serialized,
+             py::arg("reply"), py::arg("offset"),
+             "Decode serialized reply and return bytes")
+        .def("get_fv_index", &PIRClient::get_fv_index)
+        .def("get_fv_offset", &PIRClient::get_fv_offset);
+
+    py::class_<PIRServer>(m, "PIRServer")
+        .def(py::init<const seal::EncryptionParameters &, const PirParams &>(),
+             "Create a PIR server")
+        .def("set_database", &set_database_from_bytes,
+             py::arg("db"), py::arg("ele_num"), py::arg("ele_size"),
+             "Load raw database bytes")
+        .def("preprocess_database", &PIRServer::preprocess_database,
+             "Preprocess database for queries")
+        .def("set_galois_key", &set_galois_key_serialized,
+             py::arg("client_id"), py::arg("key"), py::arg("enc_params"),
+             "Set serialized Galois key for client")
+        .def("generate_reply", &generate_reply_serialized,
+             py::arg("query"), py::arg("client_id"),
+             "Generate serialized reply");
+}
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["scikit-build-core", "pybind11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "sealpir"
+version = "0.0.1"
+description = "Python bindings for SealPIR"
+authors = [{name = "SealPIR contributors"}]
+requires-python = ">=3.8"
+
+[tool.scikit-build]
+cmake.source-dir = ".."
+wheel.packages = ["sealpir"]

--- a/python/sealpir/__init__.py
+++ b/python/sealpir/__init__.py
@@ -1,0 +1,18 @@
+"""High level helpers for SealPIR."""
+
+from .sealpir import (
+    PirParams,
+    PIRClient,
+    PIRServer,
+    gen_encryption_params,
+    gen_pir_params,
+)
+
+__all__ = [
+    "PirParams",
+    "PIRClient",
+    "PIRServer",
+    "gen_encryption_params",
+    "gen_pir_params",
+]
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(SEAL 4.0 REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
 
 add_library(sealpir pir.hpp pir.cpp pir_client.hpp pir_client.cpp pir_server.hpp
   pir_server.cpp)
@@ -6,3 +7,7 @@ target_link_libraries(sealpir SEAL::seal)
 
 add_executable(main main.cpp)
 target_link_libraries(main sealpir)
+
+add_library(pysealpir MODULE ../python/bindings.cpp)
+target_link_libraries(pysealpir PRIVATE sealpir pybind11::module)
+set_target_properties(pysealpir PROPERTIES OUTPUT_NAME "sealpir" PREFIX "" SUFFIX ".so")

--- a/tests/test_pir.py
+++ b/tests/test_pir.py
@@ -1,0 +1,40 @@
+"""Verify basic SealPIR round-trip."""
+
+from sealpir import (
+    PIRClient,
+    PIRServer,
+    gen_encryption_params,
+    gen_pir_params,
+)
+
+
+def test_round_trip() -> None:
+    number_of_items = 8
+    size_per_item = 4
+    N = 2048
+    logt = 20
+    d = 1
+
+    enc_params = gen_encryption_params(N, logt)
+    pir_params = gen_pir_params(number_of_items, size_per_item, d, enc_params)
+
+    client = PIRClient(enc_params, pir_params)
+    server = PIRServer(enc_params, pir_params)
+
+    key = client.generate_galois_keys()
+    server.set_galois_key(0, key, enc_params)
+
+    database = bytes(range(number_of_items * size_per_item))
+    server.set_database(database, number_of_items, size_per_item)
+    server.preprocess_database()
+
+    element_index = 3
+    index = client.get_fv_index(element_index)
+    offset = client.get_fv_offset(element_index)
+
+    query = client.generate_query(index)
+    reply = server.generate_reply(query, 0)
+    result = client.decode_reply(reply, offset)
+
+    expected = database[element_index * size_per_item : (element_index + 1) * size_per_item]
+    assert result == expected


### PR DESCRIPTION
## Summary
- add pybind11-based module exposing PIRClient, PIRServer and parameter helpers
- integrate Python extension build with CMake and provide packaging files
- include example script and pytest verifying a basic round trip

## Testing
- `python -m pip install -e python` *(fails: Could not find a package configuration file provided by "SEAL")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sealpir')*


------
https://chatgpt.com/codex/tasks/task_e_68be5f753d5c832380137205b408f5f5