### PR TITLE
Require pybind11 2.10 for Python 3.11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You can also look at the tests in the `test` folder.
 ## Python bindings
 
 Experimental Python bindings are provided via [pybind11](https://pybind11.readthedocs.io/).
+Python 3.11 requires pybind11 version 2.10 or newer.
+
 Build and install the module locally with:
 
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -4,6 +4,8 @@ This directory contains the packaging configuration for the `sealpir` Python
 extension. Building requires a C++17 compiler, pybind11, scikit-build-core and
 Microsoft SEAL headers.
 
+Python 3.11 requires pybind11 version 2.10 or newer.
+
 To build and install locally run:
 
 ```bash

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(SEAL 4.0 REQUIRED)
-find_package(pybind11 CONFIG REQUIRED)
+find_package(pybind11 2.10 CONFIG REQUIRED)
 
 add_library(sealpir pir.hpp pir.cpp pir_client.hpp pir_client.cpp pir_server.hpp
   pir_server.cpp)


### PR DESCRIPTION
## Summary
- Require pybind11 2.10 or newer in CMake
- Document pybind11 2.10+ requirement for Python 3.11 in README files

## Testing
- `cmake -S . -B build` *(fails: Could not find SEAL)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sealpir')*


------
https://chatgpt.com/codex/tasks/task_e_68be67b908ac8323b3b2797e96b41803