### PR TITLE
Expose core headers and link sealpir in Python bindings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,5 +9,7 @@ add_executable(main main.cpp)
 target_link_libraries(main sealpir)
 
 add_library(pysealpir MODULE ../python/bindings.cpp)
-target_link_libraries(pysealpir PRIVATE sealpir pybind11::module)
+target_include_directories(pysealpir PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(pysealpir PRIVATE sealpir)
+target_link_libraries(pysealpir PRIVATE pybind11::module)
 set_target_properties(pysealpir PROPERTIES OUTPUT_NAME "sealpir" PREFIX "" SUFFIX ".so")


### PR DESCRIPTION
## Summary
- add include path for Python bindings to locate core headers
- link Python bindings against core sealpir library and pybind11

## Testing
- `cmake -S . -B build` *(fails: Could not find SEALConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68be67ba99e88323a5919e175b047570