### PR TITLE
Add context accessor to PIRClient

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -68,7 +68,7 @@ static py::bytes decode_reply_serialized(PIRClient &client,
     PirReply r;
     while (rs.rdbuf()->in_avail() > 0) {
         seal::Ciphertext ct;
-        ct.load(*client.context_, rs);
+        ct.load(*client.get_context(), rs);
         r.push_back(ct);
     }
     std::vector<uint8_t> result = client.decode_reply(r, offset);

--- a/src/pir_client.cpp
+++ b/src/pir_client.cpp
@@ -287,3 +287,7 @@ Ciphertext PIRClient::get_one() {
   }
   return ct;
 }
+
+std::shared_ptr<seal::SEALContext> PIRClient::get_context() const {
+  return context_;
+}

--- a/src/pir_client.hpp
+++ b/src/pir_client.hpp
@@ -40,6 +40,8 @@ public:
                                   std::vector<std::uint64_t> new_element,
                                   std::uint64_t offset);
 
+  std::shared_ptr<seal::SEALContext> get_context() const;
+
 private:
   seal::EncryptionParameters enc_params_;
   PirParams pir_params_;


### PR DESCRIPTION
## Summary
- expose PIRClient SEAL context via `get_context`
- update Python bindings to use the new accessor

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SEAL")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sealpir')*

------
https://chatgpt.com/codex/tasks/task_e_68be6c2573dc8323bd6fb821d0ea74ee