### PR TITLE
Return Serializable Galois keys

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -79,7 +79,7 @@ static py::bytes decode_reply_serialized(PIRClient &client,
 // Wrap generation of galois keys
 static py::bytes generate_galois_keys_serialized(PIRClient &client) {
     auto g = client.generate_galois_keys();
-    std::string s = serialize_galoiskeys(g);
+    std::string s = serialize_galoiskeys(std::move(g));
     return py::bytes(s);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
   PIRClient client(enc_params, pir_params);
   cout << "Main: Generating galois keys for client" << endl;
 
-  GaloisKeys galois_keys = client.generate_galois_keys();
+  auto galois_keys = client.generate_galois_keys();
 
   // Initialize PIR Server
   cout << "Main: Initializing server" << endl;
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
   // which is why we associate it with 0. If there are multiple PIR
   // clients, you should have each client generate a galois key,
   // and assign each client an index or id, then call the procedure below.
-  server.set_galois_key(0, galois_keys);
+  server.set_galois_key(0, galois_keys.release());
 
   cout << "Main: Creating the database with random data (this may take some "
           "time) ..."

--- a/src/pir_client.cpp
+++ b/src/pir_client.cpp
@@ -238,7 +238,7 @@ Plaintext PIRClient::decode_reply(PirReply &reply) {
   return fail;
 }
 
-GaloisKeys PIRClient::generate_galois_keys() {
+Serializable<GaloisKeys> PIRClient::generate_galois_keys() {
   // Generate the Galois keys needed for coeff_select.
   vector<uint32_t> galois_elts;
   int N = enc_params_.poly_modulus_degree();
@@ -252,9 +252,7 @@ GaloisKeys PIRClient::generate_galois_keys() {
     // cout << galois_elts.back() << ", ";
     //#endif
   }
-  GaloisKeys gal_keys;
-  keygen_->create_galois_keys(galois_elts, gal_keys);
-  return gal_keys;
+  return keygen_->create_galois_keys(galois_elts);
 }
 
 Plaintext PIRClient::replace_element(Plaintext pt, vector<uint64_t> new_element,

--- a/src/pir_client.hpp
+++ b/src/pir_client.hpp
@@ -27,7 +27,7 @@ public:
 
   seal::Plaintext decrypt(seal::Ciphertext ct);
 
-  seal::GaloisKeys generate_galois_keys();
+  seal::Serializable<seal::GaloisKeys> generate_galois_keys();
 
   // Index and offset of an element in an FV plaintext
   uint64_t get_fv_index(uint64_t element_index);

--- a/test/expand_test.cpp
+++ b/test/expand_test.cpp
@@ -49,11 +49,11 @@ int main(int argc, char *argv[]) {
 
   // Initialize PIR client....
   PIRClient client(enc_params, pir_params);
-  GaloisKeys galois_keys = client.generate_galois_keys();
+  auto galois_keys = client.generate_galois_keys();
 
   // Set galois key for client with id 0
   cout << "Main: Setting Galois keys...";
-  server.set_galois_key(0, galois_keys);
+  server.set_galois_key(0, galois_keys.release());
 
   random_device rd;
   // Choose an index of an element in the DB

--- a/test/query_test.cpp
+++ b/test/query_test.cpp
@@ -87,11 +87,11 @@ int query_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
 
   // Initialize PIR client....
   PIRClient client(enc_params, pir_params);
-  GaloisKeys galois_keys = client.generate_galois_keys();
+  auto galois_keys = client.generate_galois_keys();
 
   // Set galois key for client with id 0
   cout << "Main: Setting Galois keys...";
-  server.set_galois_key(0, galois_keys);
+  server.set_galois_key(0, galois_keys.release());
 
   // Measure database setup
   auto time_pre_s = high_resolution_clock::now();

--- a/test/replace_test.cpp
+++ b/test/replace_test.cpp
@@ -82,11 +82,11 @@ int replace_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
   // Initialize PIR client....
   PIRClient client(enc_params, pir_params);
   Ciphertext one_ct = client.get_one();
-  GaloisKeys galois_keys = client.generate_galois_keys();
+  auto galois_keys = client.generate_galois_keys();
 
   // Set galois key for client with id 0
   cout << "Main: Setting Galois keys...";
-  server.set_galois_key(0, galois_keys);
+  server.set_galois_key(0, galois_keys.release());
 
   // Measure database setup
   auto time_pre_s = high_resolution_clock::now();


### PR DESCRIPTION
## Summary
- Return `Serializable<GaloisKeys>` from `PIRClient::generate_galois_keys`
- Update Python bindings to serialize the new `Serializable` object
- Adjust callers to release Galois keys when setting them on the server

## Testing
- `cmake -S . -B build` *(fails: Could not find SEAL package)*
- `python -m pytest tests/test_pir.py` *(fails: ModuleNotFoundError: No module named 'sealpir')*

------
https://chatgpt.com/codex/tasks/task_e_68be6c27f5008323bf6c0629424ada2b