### PR TITLE
Accept Serializable galois keys

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
   // which is why we associate it with 0. If there are multiple PIR
   // clients, you should have each client generate a galois key,
   // and assign each client an index or id, then call the procedure below.
-  server.set_galois_key(0, galois_keys.release());
+  server.set_galois_key(0, galois_keys);
 
   cout << "Main: Creating the database with random data (this may take some "
           "time) ..."

--- a/src/pir_server.cpp
+++ b/src/pir_server.cpp
@@ -136,8 +136,13 @@ void PIRServer::set_database(const std::unique_ptr<const uint8_t[]> &bytes,
   set_database(move(result));
 }
 
+void PIRServer::set_galois_key(uint32_t client_id,
+                               seal::Serializable<seal::GaloisKeys> &galkey) {
+  galoisKeys_[client_id] = galkey.release();
+}
+
 void PIRServer::set_galois_key(uint32_t client_id, seal::GaloisKeys galkey) {
-  galoisKeys_[client_id] = galkey;
+  galoisKeys_[client_id] = std::move(galkey);
 }
 
 PirQuery PIRServer::deserialize_query(stringstream &stream) {

--- a/src/pir_server.hpp
+++ b/src/pir_server.hpp
@@ -28,6 +28,8 @@ public:
   // bytes written
   int serialize_reply(PirReply &reply, std::stringstream &stream);
 
+  void set_galois_key(std::uint32_t client_id,
+                      seal::Serializable<seal::GaloisKeys> &galkey);
   void set_galois_key(std::uint32_t client_id, seal::GaloisKeys galkey);
 
   // Below simple operations are for interacting with the database WITHOUT PIR.

--- a/test/expand_test.cpp
+++ b/test/expand_test.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[]) {
 
   // Set galois key for client with id 0
   cout << "Main: Setting Galois keys...";
-  server.set_galois_key(0, galois_keys.release());
+  server.set_galois_key(0, galois_keys);
 
   random_device rd;
   // Choose an index of an element in the DB

--- a/test/query_test.cpp
+++ b/test/query_test.cpp
@@ -91,7 +91,7 @@ int query_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
 
   // Set galois key for client with id 0
   cout << "Main: Setting Galois keys...";
-  server.set_galois_key(0, galois_keys.release());
+  server.set_galois_key(0, galois_keys);
 
   // Measure database setup
   auto time_pre_s = high_resolution_clock::now();

--- a/test/replace_test.cpp
+++ b/test/replace_test.cpp
@@ -86,7 +86,7 @@ int replace_test(uint64_t num_items, uint64_t item_size, uint32_t degree,
 
   // Set galois key for client with id 0
   cout << "Main: Setting Galois keys...";
-  server.set_galois_key(0, galois_keys.release());
+  server.set_galois_key(0, galois_keys);
 
   // Measure database setup
   auto time_pre_s = high_resolution_clock::now();


### PR DESCRIPTION
## Summary
- allow PIRServer to accept `Serializable<GaloisKeys>` and unwrap internally
- use serializable galois keys directly in main and tests

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SEAL")*
- `pytest -q tests/test_pir.py` *(fails: ModuleNotFoundError: No module named 'sealpir')*


------
https://chatgpt.com/codex/tasks/task_e_68be6f86a2a48323b18675b368180415