### PR TITLE
Use move_to for Galois key

### DIFF
--- a/src/pir_server.cpp
+++ b/src/pir_server.cpp
@@ -138,7 +138,7 @@ void PIRServer::set_database(const std::unique_ptr<const uint8_t[]> &bytes,
 
 void PIRServer::set_galois_key(uint32_t client_id,
                                seal::Serializable<seal::GaloisKeys> &galkey) {
-  galoisKeys_[client_id] = galkey.release();
+  galkey.move_to(galoisKeys_[client_id]);
 }
 
 void PIRServer::set_galois_key(uint32_t client_id, seal::GaloisKeys galkey) {


### PR DESCRIPTION
## Summary
- use `move_to` when setting Galois key from a serializable input

## Testing
- `cmake -S . -B build` *(fails: Could not find SEAL package)*
- `apt-get install -y libseal-dev` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68be7945694883239c93608b73637080