### PR TITLE
Rename Python package to pysealpir

### DIFF
--- a/examples/basic_pir.py
+++ b/examples/basic_pir.py
@@ -1,6 +1,6 @@
 """Minimal round-trip example using SealPIR bindings."""
 
-from sealpir import (
+from pysealpir import (
     PIRClient,
     PIRServer,
     gen_encryption_params,

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # SealPIR Python bindings
 
-This directory contains the packaging configuration for the `sealpir` Python
+This directory contains the packaging configuration for the `pysealpir` Python
 extension. Building requires a C++17 compiler, pybind11, scikit-build-core and
 Microsoft SEAL headers.
 
@@ -13,4 +13,4 @@ pip install -e .
 ```
 
 This will compile the extension via CMake and make the module available as
-`sealpir`.
+`pysealpir`.

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -95,7 +95,7 @@ static void set_galois_key_serialized(PIRServer &server, std::uint32_t client_id
     delete g;
 }
 
-PYBIND11_MODULE(sealpir, m) {
+PYBIND11_MODULE(_pysealpir, m) {
     m.doc() = "Python bindings for SealPIR";
 
     py::class_<seal::EncryptionParameters>(m, "EncryptionParameters")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["scikit-build-core", "pybind11"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "sealpir"
+name = "pysealpir"
 version = "0.0.1"
 description = "Python bindings for SealPIR"
 authors = [{name = "SealPIR contributors"}]
@@ -11,4 +11,4 @@ requires-python = ">=3.8"
 
 [tool.scikit-build]
 cmake.source-dir = ".."
-wheel.packages = ["sealpir"]
+wheel.packages = ["pysealpir"]

--- a/python/pysealpir/__init__.py
+++ b/python/pysealpir/__init__.py
@@ -1,6 +1,6 @@
 """High level helpers for SealPIR."""
 
-from .sealpir import (
+from ._pysealpir import (
     PirParams,
     PIRClient,
     PIRServer,

--- a/python_tests/test_pir.py
+++ b/python_tests/test_pir.py
@@ -1,6 +1,6 @@
 """Verify basic SealPIR round-trip."""
 
-from sealpir import (
+from pysealpir import (
     PIRClient,
     PIRServer,
     gen_encryption_params,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,4 +17,4 @@ target_include_directories(pysealpir PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(pysealpir PRIVATE sealpir)
 target_link_libraries(pysealpir PRIVATE pybind11::module)
 
-set_target_properties(pysealpir PROPERTIES OUTPUT_NAME "sealpir" PREFIX "" SUFFIX ".so")
+set_target_properties(pysealpir PROPERTIES OUTPUT_NAME "_pysealpir" PREFIX "" SUFFIX ".so")


### PR DESCRIPTION
## Summary
- rename Python bindings package to `pysealpir`
- adjust example and tests to import `pysealpir`
- clarify Python test folder naming

## Testing
- `pip install -e python` *(fails: Could not find package configuration file provided by "SEAL" )*
- `pytest python_tests/test_pir.py` *(fails: No module named 'pysealpir')*

------
https://chatgpt.com/codex/tasks/task_e_68be835a2e748323bdd1c04f3441d065